### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.google.osdetector' version '1.6.2' apply false
-    id 'me.champeau.gradle.jmh' version '0.5.0' apply false
+    id 'me.champeau.jmh' version '0.6.4' apply false
 }
 
 allprojects {
@@ -33,7 +33,7 @@ apply from: "${rootDir}/gradle/scripts/build-flags.gradle"
 configure(projectsWithFlags('java')) {
 
     // Apply common plugins.
-    apply plugin: 'me.champeau.gradle.jmh'
+    apply plugin: 'me.champeau.jmh'
 
     // Common properties and functions.
     ext {

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -4,9 +4,9 @@
 #
 boms:
 - com.fasterxml.jackson:jackson-bom:2.12.3
-- com.linecorp.armeria:armeria-bom:1.7.2
-- io.micrometer:micrometer-bom:1.6.6
-- org.junit:junit-bom:5.7.1
+- com.linecorp.armeria:armeria-bom:1.8.0
+- io.micrometer:micrometer-bom:1.7.0
+- org.junit:junit-bom:5.7.2
 
 ch.qos.logback:
   logback-classic:
@@ -17,13 +17,13 @@ ch.qos.logback:
 com.beust:
   # Please check `jcommander` version of Maven Central Repository before updating
   # https://search.maven.org/artifact/com.beust/jcommander
-  jcommander: { version: '1.78' }
+  jcommander: { version: '1.81' }
 
 com.boazj.gradle:
   gradle-log-plugin: { version: '0.1.0' }
 
 com.bmuschko:
-  gradle-docker-plugin: { version: '6.7.0' }
+  gradle-docker-plugin: { version: '7.0.0' }
 
 com.craigburke.gradle:
   client-dependencies: { version: '1.4.1' }
@@ -49,9 +49,9 @@ com.fasterxml.jackson.core:
 
 com.github.ben-manes.caffeine:
   caffeine:
-    version: '2.9.0'
+    version: '2.9.1'
     javadocs:
-    - https://www.javadoc.io/doc/com.github.ben-manes.caffeine/caffeine/2.9.0/
+    - https://www.javadoc.io/doc/com.github.ben-manes.caffeine/caffeine/2.9.1/
 
 com.github.jengelman.gradle.plugins:
   shadow: { version: '6.1.0' }
@@ -160,8 +160,8 @@ org.junit.jupiter:
 kr.motd.gradle:
   sphinx-gradle-plugin: { version: '2.10.1' }
 
-me.champeau.gradle:
-  jmh-gradle-plugin: { version: '0.5.3' }
+me.champeau.jmh:
+  jmh-gradle-plugin: { version: '0.6.4' }
 
 net.javacrumbs.json-unit:
   json-unit: { version: &JSON_UNIT_VERSION '2.25.0' }
@@ -205,7 +205,7 @@ org.assertj:
   assertj-core: { version: '3.19.0' }
 
 org.awaitility:
-  awaitility: { version: '4.0.3' }
+  awaitility: { version: '4.1.0' }
 
 org.hamcrest:
   hamcrest-library: { version: '2.2' }
@@ -214,7 +214,7 @@ org.eclipse.jetty.alpn:
   alpn-api: { version: '1.1.3.v20160715' }
 
 org.eclipse.jgit:
-  org.eclipse.jgit: { version: &JGIT_VERSION '5.11.0.202103091610-r' }
+  org.eclipse.jgit: { version: &JGIT_VERSION '5.11.1.202105131744-r' }
   org.eclipse.jgit.ssh.jsch: { version: *JGIT_VERSION }
 
 org.hibernate.validator:
@@ -224,14 +224,14 @@ org.javassist:
   javassist: { version: '3.27.0-GA' }
 
 org.mockito:
-  mockito-core: { version: &MOCKITO_VERSION '3.9.0' }
+  mockito-core: { version: &MOCKITO_VERSION '3.10.0' }
   mockito-junit-jupiter: { version: *MOCKITO_VERSION }
 
 org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.10' }
 
 org.openjdk.jmh:
-  jmh-core: { version: &JMH_VERSION '1.29' }
+  jmh-core: { version: &JMH_VERSION '1.31' }
   jmh-generator-annprocess: { version: *JMH_VERSION }
 
 org.slf4j:

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -22,8 +22,9 @@ com.beust:
 com.boazj.gradle:
   gradle-log-plugin: { version: '0.1.0' }
 
+# Don't update `gradle-docker-plugin` to '7.x' that requires Java 11
 com.bmuschko:
-  gradle-docker-plugin: { version: '7.0.0' }
+  gradle-docker-plugin: { version: '6.7.0' }
 
 com.craigburke.gradle:
   client-dependencies: { version: '1.4.1' }

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     repositories {
         mavenCentral()
         jcenter()
+        gradlePluginPortal()
     }
     dependencies {
         classpath "com.boazj.gradle:gradle-log-plugin:${managedVersions['com.boazj.gradle:gradle-log-plugin']}"

--- a/server-auth/webapp/build.gradle
+++ b/server-auth/webapp/build.gradle
@@ -53,7 +53,7 @@ tasks.assemble.dependsOn tasks.buildWebApp
 tasks.clean.dependsOn tasks.cleanNodeModules
 
 node {
-    version = '10.19.0'
-    yarnVersion = '1.17.3'
+    version = '16.1.0'
+    yarnVersion = '1.22.10'
     download = true
 }


### PR DESCRIPTION
#### Motivation
- Try to use `@TempDir` in some tests to see if file deletion logic on Windows has been improved

#### Modifications
- Replace some usages of `TemporaryFolderExtension` with JUnit's `@TempDir`- Armeria 1.7.2 -> 1.8.0
- Caffeine 2.9.0 -> 2.9.1
- jcommander 1.78 -> 1.81
- JGit 5.11.0 -> 5.11.1
- Micrometer 1.6.6 -> 1.7.0
- Mocktio 3.9.0 -> 3.10.0
- Build
  - awaitility 4.0.3 -> 4.1.0
  - gradle-docker-plugin 6.7.0 -> 7.0.0
  - jmh-gradle-plugin 0.5.3 -> 0.6.4
  - jmh 1.29 -> 1.31
  - JUnit 5.7.1 -> 5.7.2