### PR TITLE
Migrate Dockser registry from Docker Hub to GitHub container registry

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -6,6 +6,8 @@ on:
 
 env:
   LC_ALL: 'en_US.UTF-8'
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   push_to_registry:
@@ -39,14 +41,18 @@ jobs:
             return version
           result-encoding: string
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v1
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
         with:
+          registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Push Docker image
-        run: |
-          docker push line/centraldogma:${{ steps.release-version.outputs.result }}
-          docker push line/centraldogma:latest
-        shell: bash
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags:
+            - ${{ env.IMAGE_NAME }}:${{ steps.release-version.outputs.result }}
+            - ${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
Motivation:

Although Docker decided to [revert sunset the “Docker Free Team” plan](https://www.docker.com/blog/we-apologize-we-did-a-terrible-job-announcing-the-end-of-docker-free-teams/), we still think it is worth migrating our container registry to GitHub. Because users will easily checkout the images on our GitHub repository.

Modifications:

- Fixed to publish docker images to `ghcr.io`

Result:

You can now get Central Dogma docker images from `ghrc.io`
```
docker pull ghrc.io/line/centraldogma:latest
```